### PR TITLE
Upgrade regex

### DIFF
--- a/src/main/java/com/makingsense/sap/purchase/controllers/PurchaseController.java
+++ b/src/main/java/com/makingsense/sap/purchase/controllers/PurchaseController.java
@@ -1,5 +1,6 @@
 package com.makingsense.sap.purchase.controllers;
 
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.makingsense.sap.purchase.models.JiraPurchaseTicket;
@@ -41,6 +42,10 @@ public class PurchaseController {
         this.mapper = mapper.copy();
         final SimpleModule module = new SimpleModule();
         module.addSerializer(Purchase.class, new PurchaseSerializer());
+        mapper.configure(
+                JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature(),
+                true
+        );
 
         this.mapper.registerModule(module);
     }

--- a/src/main/java/com/makingsense/sap/purchase/models/JiraPurchaseTicket.java
+++ b/src/main/java/com/makingsense/sap/purchase/models/JiraPurchaseTicket.java
@@ -24,15 +24,15 @@ public class JiraPurchaseTicket {
     @NotBlank(message = "The company is mandatory.")
     private String company;
 
-    @Pattern(regexp = "[a-zA-Z0-9]+[ ]*-[ ]*[a-zA-Z0-9[ ]*]+", message = "Business unit attribute has invalid format.")
+    @Pattern(regexp = "[a-zA-Z0-9]+[ ]*-.+", message = "Business unit attribute has invalid format.")
     @NotBlank(message = "The business unit is mandatory.")
     private String businessUnit;
 
-    @Pattern(regexp = "[a-zA-Z0-9]+[ ]*-[ ]*[a-zA-Z0-9[ ]*]+", message = "Department attribute has invalid format.")
+    @Pattern(regexp = "[a-zA-Z0-9]+[ ]*-.+", message = "Department attribute has invalid format.")
     @NotBlank(message = "The department is mandatory.")
     private String department;
 
-    @Pattern(regexp = "[a-zA-Z0-9]+[ ]*-[ ]*[a-zA-Z0-9[ ]*]+", message = "Location attribute has invalid format.")
+    @Pattern(regexp = "[a-zA-Z0-9]+[ ]*-.+", message = "Location attribute has invalid format.")
     @NotBlank(message = "The ticket location is mandatory.")
     private String location;
 


### PR DESCRIPTION
# Description

- Goal: support symbols on different properties of Jira. Also, the ticket description have not escaped characters, so we change the ObjectMapper so \n can be supported. 